### PR TITLE
Users should not see sykmeldinger that has Status SLETTET

### DIFF
--- a/src/main/kotlin/no/nav/syfo/sykmeldingstatus/SykmeldingStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmeldingstatus/SykmeldingStatus.kt
@@ -9,7 +9,7 @@ data class SykmeldingStatusEvent(
 )
 
 enum class StatusEvent {
-    APEN, AVBRUTT, UTGATT, SENDT, BEKREFTET
+    APEN, AVBRUTT, UTGATT, SENDT, BEKREFTET, SLETTET
 }
 
 data class SykmeldingStatusEventDTO(

--- a/src/test/kotlin/no/nav/syfo/sykmeldingstatus/SykmeldingStatusServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/sykmeldingstatus/SykmeldingStatusServiceSpek.kt
@@ -1,7 +1,5 @@
 package no.nav.syfo.sykmeldingstatus
 
-import java.time.LocalDateTime
-import kotlin.test.assertFailsWith
 import no.nav.syfo.aksessering.SykmeldingService
 import no.nav.syfo.persistering.opprettBehandlingsutfall
 import no.nav.syfo.persistering.opprettSykmeldingsdokument
@@ -16,6 +14,8 @@ import org.amshove.kluent.shouldEqual
 import org.postgresql.util.PSQLException
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
+import java.time.LocalDateTime
+import kotlin.test.assertFailsWith
 
 class SykmeldingStatusServiceSpek : Spek({
 
@@ -69,6 +69,42 @@ class SykmeldingStatusServiceSpek : Spek({
             val status = SykmeldingStatusEvent("uuid", confirmedDateTime, StatusEvent.BEKREFTET)
             sykmeldingStatusService.registrerStatus(status)
             assertFailsWith(PSQLException::class) { sykmeldingStatusService.registrerStatus(status) }
+        }
+
+        it("Should not get sykmeling with status SLETTET") {
+            val confirmedDateTime = LocalDateTime.now()
+            val status = SykmeldingStatusEvent("uuid", confirmedDateTime, StatusEvent.APEN)
+            val deletedStatus = SykmeldingStatusEvent("uuid", confirmedDateTime.plusHours(1), StatusEvent.SLETTET)
+            sykmeldingStatusService.registrerStatus(status)
+            sykmeldingStatusService.registrerStatus(deletedStatus)
+
+            val sykmeldinger = sykmeldingService.hentSykmeldinger("pasientFnr")
+
+            sykmeldinger shouldEqual emptyList()
+        }
+
+        it("should only get sykmelidnger where status is not SLETTET") {
+            val copySykmeldingDokument = testSykmeldingsdokument.copy(id = "uuid2")
+            val copySkymeldingopplysning = testSykmeldingsopplysninger.copy(
+                    id = "uuid2",
+                    pasientFnr = "pasientFnr"
+            )
+            database.connection.opprettSykmeldingsopplysninger(copySkymeldingopplysning)
+            database.connection.opprettSykmeldingsdokument(copySykmeldingDokument)
+            database.connection.opprettBehandlingsutfall(testBehandlingsutfall.copy(id = "uuid2"))
+
+            val confirmedDateTime = LocalDateTime.now()
+            val status = SykmeldingStatusEvent("uuid", confirmedDateTime, StatusEvent.APEN)
+            val deletedStatus = SykmeldingStatusEvent("uuid", confirmedDateTime.plusHours(1), StatusEvent.SLETTET)
+            val status2 = SykmeldingStatusEvent("uuid2", confirmedDateTime, StatusEvent.APEN)
+            sykmeldingStatusService.registrerStatus(status)
+            sykmeldingStatusService.registrerStatus(status2)
+            sykmeldingStatusService.registrerStatus(deletedStatus)
+
+            val sykmeldinger = sykmeldingService.hentSykmeldinger("pasientFnr")
+
+            sykmeldinger.size shouldEqual 1
+            sykmeldinger.first().id shouldEqual "uuid2"
         }
     }
 })


### PR DESCRIPTION
Filtrerer ut sykmeldinger med status slettet i selve spørringen mot databasen. Ser også at den spørringen kanskje burde ha vært endret litt på. Den returnerer også bare sykmeldinger som har fått et behandlingsutfall og i dag er det mange sykmeldinger i databasen uten behandlingsutfall ca 90%. 