### PR TITLE
Fjerne gml svar

### DIFF
--- a/src/main/kotlin/no/nav/syfo/Bootstrap.kt
+++ b/src/main/kotlin/no/nav/syfo/Bootstrap.kt
@@ -133,7 +133,7 @@ fun createListener(applicationState: ApplicationState, action: suspend Coroutine
             } catch (e: TrackableException) {
                 log.error("En uhåndtert feil oppstod, applikasjonen restarter {}", fields(e.loggingMeta), e.cause)
             } catch (ex: Exception) {
-                log.error("Noe gikk galt", ex.message)
+                log.error("Noe gikk galt", ex.cause)
             } finally {
                 applicationState.alive = false
             }

--- a/src/main/kotlin/no/nav/syfo/aksessering/db/SykmeldingAksesseringQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/aksessering/db/SykmeldingAksesseringQueries.kt
@@ -1,6 +1,8 @@
 package no.nav.syfo.aksessering.db
 
 import com.fasterxml.jackson.module.kotlin.readValue
+import java.sql.ResultSet
+import java.time.LocalDateTime
 import no.nav.syfo.db.DatabaseInterface
 import no.nav.syfo.db.toList
 import no.nav.syfo.domain.Arbeidsgiver
@@ -10,14 +12,12 @@ import no.nav.syfo.domain.Gradert
 import no.nav.syfo.domain.Periodetype
 import no.nav.syfo.domain.Sykmelding
 import no.nav.syfo.domain.Sykmeldingsperiode
-import no.nav.syfo.objectMapper
-import no.nav.syfo.sykmeldingstatus.StatusEvent
-import java.sql.ResultSet
-import java.time.LocalDateTime
 import no.nav.syfo.model.Arbeidsgiver as ModelArbeidsgiver
 import no.nav.syfo.model.Gradert as ModelGradert
 import no.nav.syfo.model.HarArbeidsgiver as ModelHarArbeidsgiver
 import no.nav.syfo.model.Periode as ModelPeriode
+import no.nav.syfo.objectMapper
+import no.nav.syfo.sykmeldingstatus.StatusEvent
 
 fun DatabaseInterface.hentSykmeldinger(fnr: String): List<Sykmelding> =
         connection.use { connection ->

--- a/src/main/kotlin/no/nav/syfo/sykmeldingstatus/SykmeldingStatusQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmeldingstatus/SykmeldingStatusQueries.kt
@@ -1,142 +1,164 @@
 package no.nav.syfo.sykmeldingstatus
 
 import java.lang.RuntimeException
+import java.sql.Connection
 import java.sql.Statement
 import java.sql.Timestamp
 import no.nav.syfo.db.DatabaseInterface
+import no.nav.syfo.log
 
 fun DatabaseInterface.registerStatus(sykmeldingStatusEvent: SykmeldingStatusEvent) {
     connection.use { connection ->
-        connection.prepareStatement(
-            """
-                    INSERT INTO sykmeldingstatus(sykmelding_id, event_timestamp, event) VALUES (?, ?, ?)
-                    """
-        ).use {
-            it.setString(1, sykmeldingStatusEvent.sykmeldingId)
-            it.setTimestamp(2, Timestamp.valueOf(sykmeldingStatusEvent.timestamp))
-            it.setString(3, sykmeldingStatusEvent.event.name)
-            it.execute()
-        }
+        connection.registerStatus(sykmeldingStatusEvent)
         connection.commit()
     }
 }
 
-fun DatabaseInterface.lagreArbeidsgiver(sykmeldingSendEvent: SykmeldingSendEvent) {
+fun DatabaseInterface.registrerSendt(sykmeldingSendEvent: SykmeldingSendEvent, sykmeldingStatusEvent: SykmeldingStatusEvent) {
     connection.use { connection ->
-        connection.prepareStatement(
-            """
-                    INSERT INTO arbeidsgiver(sykmelding_id, orgnummer, juridisk_orgnummer, navn) VALUES (?, ?, ?, ?)
-                    """
-        ).use {
-            it.setString(1, sykmeldingSendEvent.sykmeldingId)
-            it.setString(2, sykmeldingSendEvent.arbeidsgiver.orgnummer)
-            it.setString(3, sykmeldingSendEvent.arbeidsgiver.juridiskOrgnummer)
-            it.setString(4, sykmeldingSendEvent.arbeidsgiver.orgnavn)
-            it.execute()
+        connection.slettGamleSvarHvisFinnesFraFor(sykmeldingSendEvent.sykmeldingId)
+        connection.registerStatus(sykmeldingStatusEvent)
+        connection.lagreArbeidsgiver(sykmeldingSendEvent)
+        connection.lagreSporsmalOgSvar(sykmeldingSendEvent.sporsmal)
+        connection.commit()
+    }
+}
+
+fun DatabaseInterface.registrerBekreftet(sykmeldingBekreftEvent: SykmeldingBekreftEvent, sykmeldingStatusEvent: SykmeldingStatusEvent) {
+    connection.use { connection ->
+        connection.slettGamleSvarHvisFinnesFraFor(sykmeldingBekreftEvent.sykmeldingId)
+        connection.registerStatus(sykmeldingStatusEvent)
+        sykmeldingBekreftEvent.sporsmal?.forEach {
+            connection.lagreSporsmalOgSvar(it)
         }
         connection.commit()
     }
 }
 
-fun DatabaseInterface.lagreSporsmalOgSvar(sporsmal: Sporsmal) {
-    var spmId: Int? = finnSporsmal(sporsmal)
+private fun Connection.slettGamleSvarHvisFinnesFraFor(sykmeldingId: String) {
+    val svarFinnesFraFor = this.svarFinnesFraFor(sykmeldingId)
+    if (svarFinnesFraFor) {
+        log.info("Sletter tidligere svar for sykmelding {}", sykmeldingId)
+        this.slettAlleSvar(sykmeldingId)
+    }
+}
+
+private fun Connection.svarFinnesFraFor(sykmeldingId: String): Boolean =
+    this.prepareStatement(
+        """
+                SELECT 1 FROM svar WHERE sykmelding_id=?;
+                """
+    ).use {
+        it.setString(1, sykmeldingId)
+        it.executeQuery().next()
+    }
+
+private fun Connection.registerStatus(sykmeldingStatusEvent: SykmeldingStatusEvent) {
+    this.prepareStatement(
+        """
+                INSERT INTO sykmeldingstatus(sykmelding_id, event_timestamp, event) VALUES (?, ?, ?)
+                """
+    ).use {
+        it.setString(1, sykmeldingStatusEvent.sykmeldingId)
+        it.setTimestamp(2, Timestamp.valueOf(sykmeldingStatusEvent.timestamp))
+        it.setString(3, sykmeldingStatusEvent.event.name)
+        it.execute()
+    }
+}
+
+private fun Connection.lagreArbeidsgiver(sykmeldingSendEvent: SykmeldingSendEvent) {
+    this.prepareStatement(
+        """
+                INSERT INTO arbeidsgiver(sykmelding_id, orgnummer, juridisk_orgnummer, navn) VALUES (?, ?, ?, ?)
+                """
+    ).use {
+        it.setString(1, sykmeldingSendEvent.sykmeldingId)
+        it.setString(2, sykmeldingSendEvent.arbeidsgiver.orgnummer)
+        it.setString(3, sykmeldingSendEvent.arbeidsgiver.juridiskOrgnummer)
+        it.setString(4, sykmeldingSendEvent.arbeidsgiver.orgnavn)
+        it.execute()
+    }
+}
+
+private fun Connection.slettAlleSvar(sykmeldingId: String) {
+    this.slettArbeidsgiver(sykmeldingId)
+    this.slettSvar(sykmeldingId)
+}
+
+private fun Connection.lagreSporsmalOgSvar(sporsmal: Sporsmal) {
+    var spmId: Int?
+    spmId = this.finnSporsmal(sporsmal)
     if (spmId == null) {
-        spmId = lagreSporsmal(sporsmal)
+        spmId = this.lagreSporsmal(sporsmal)
     }
-    lagreSvar(spmId, sporsmal.svar)
+    this.lagreSvar(spmId, sporsmal.svar)
 }
 
-fun DatabaseInterface.lagreSporsmal(sporsmal: Sporsmal): Int {
+private fun Connection.lagreSporsmal(sporsmal: Sporsmal): Int {
     var spmId: Int? = null
-    connection.use { connection ->
-        connection.prepareStatement(
-            """
-                    INSERT INTO sporsmal(shortName, tekst) VALUES (?, ?)
-                    """,
-            Statement.RETURN_GENERATED_KEYS
-        ).use {
-            it.setString(1, sporsmal.shortName.name)
-            it.setString(2, sporsmal.tekst)
-            it.execute()
-            if (it.generatedKeys.next()) {
-                spmId = it.generatedKeys.getInt(1)
-            }
+    this.prepareStatement(
+        """
+                INSERT INTO sporsmal(shortName, tekst) VALUES (?, ?)
+                """,
+        Statement.RETURN_GENERATED_KEYS
+    ).use {
+        it.setString(1, sporsmal.shortName.name)
+        it.setString(2, sporsmal.tekst)
+        it.execute()
+        if (it.generatedKeys.next()) {
+            spmId = it.generatedKeys.getInt(1)
         }
-        connection.commit()
     }
     return spmId ?: throw RuntimeException("Fant ikke id for spørsmål som nettopp ble lagret")
 }
 
-fun DatabaseInterface.finnSporsmal(sporsmal: Sporsmal): Int? {
-    connection.use { connection ->
-        connection.prepareStatement(
-            """
+private fun Connection.finnSporsmal(sporsmal: Sporsmal): Int? {
+    this.prepareStatement(
+        """
                 SELECT sporsmal.id
                 FROM sporsmal
                 WHERE shortName=? AND tekst=?;
                 """
-        ).use {
-            it.setString(1, sporsmal.shortName.name)
-            it.setString(2, sporsmal.tekst)
-            val rs = it.executeQuery()
-            return if (rs.next()) rs.getInt(1) else null
-        }
+    ).use {
+        it.setString(1, sporsmal.shortName.name)
+        it.setString(2, sporsmal.tekst)
+        val rs = it.executeQuery()
+        return if (rs.next()) rs.getInt(1) else null
     }
 }
 
-private fun DatabaseInterface.lagreSvar(sporsmalId: Int, svar: Svar) {
-    connection.use { connection ->
-        connection.prepareStatement(
-            """
-                    INSERT INTO svar(sykmelding_id, sporsmal_id, svartype, svar) VALUES (?, ?, ?, ?)
-                    """
-        ).use {
-            it.setString(1, svar.sykmeldingId)
-            it.setInt(2, sporsmalId)
-            it.setString(3, svar.svartype.name)
-            it.setString(4, svar.svar)
-            it.execute()
-        }
-        connection.commit()
+private fun Connection.lagreSvar(sporsmalId: Int, svar: Svar) {
+    this.prepareStatement(
+        """
+                INSERT INTO svar(sykmelding_id, sporsmal_id, svartype, svar) VALUES (?, ?, ?, ?)
+                """
+    ).use {
+        it.setString(1, svar.sykmeldingId)
+        it.setInt(2, sporsmalId)
+        it.setString(3, svar.svartype.name)
+        it.setString(4, svar.svar)
+        it.execute()
     }
 }
 
-fun DatabaseInterface.svarFinnesFraFor(sykmeldingId: String): Boolean =
-    connection.use { connection ->
-        connection.prepareStatement(
-            """
-                    SELECT 1 FROM svar WHERE sykmelding_id=?;
-                    """
-        ).use {
-            it.setString(1, sykmeldingId)
-            it.executeQuery().next()
-        }
-    }
-
-fun DatabaseInterface.slettArbeidsgiver(sykmeldingId: String) {
-    connection.use { connection ->
-        connection.prepareStatement(
-            """
-                    DELETE FROM arbeidsgiver WHERE sykmelding_id=?;
-                    """
-        ).use {
-            it.setString(1, sykmeldingId)
-            it.execute()
-        }
-        connection.commit()
+private fun Connection.slettArbeidsgiver(sykmeldingId: String) {
+    this.prepareStatement(
+        """
+                DELETE FROM arbeidsgiver WHERE sykmelding_id=?;
+                """
+    ).use {
+        it.setString(1, sykmeldingId)
+        it.execute()
     }
 }
 
-fun DatabaseInterface.slettSvar(sykmeldingId: String) {
-    connection.use { connection ->
-        connection.prepareStatement(
-            """
-                    DELETE FROM svar WHERE sykmelding_id=?;
-                    """
-        ).use {
-            it.setString(1, sykmeldingId)
-            it.execute()
-        }
-        connection.commit()
+private fun Connection.slettSvar(sykmeldingId: String) {
+    this.prepareStatement(
+        """
+                DELETE FROM svar WHERE sykmelding_id=?;
+                """
+    ).use {
+        it.setString(1, sykmeldingId)
+        it.execute()
     }
 }

--- a/src/main/kotlin/no/nav/syfo/sykmeldingstatus/SykmeldingStatusQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmeldingstatus/SykmeldingStatusQueries.kt
@@ -100,3 +100,43 @@ private fun DatabaseInterface.lagreSvar(sporsmalId: Int, svar: Svar) {
         connection.commit()
     }
 }
+
+fun DatabaseInterface.svarFinnesFraFor(sykmeldingId: String): Boolean =
+    connection.use { connection ->
+        connection.prepareStatement(
+            """
+                    SELECT 1 FROM svar WHERE sykmelding_id=?;
+                    """
+        ).use {
+            it.setString(1, sykmeldingId)
+            it.executeQuery().next()
+        }
+    }
+
+fun DatabaseInterface.slettArbeidsgiver(sykmeldingId: String) {
+    connection.use { connection ->
+        connection.prepareStatement(
+            """
+                    DELETE FROM arbeidsgiver WHERE sykmelding_id=?;
+                    """
+        ).use {
+            it.setString(1, sykmeldingId)
+            it.execute()
+        }
+        connection.commit()
+    }
+}
+
+fun DatabaseInterface.slettSvar(sykmeldingId: String) {
+    connection.use { connection ->
+        connection.prepareStatement(
+            """
+                    DELETE FROM svar WHERE sykmelding_id=?;
+                    """
+        ).use {
+            it.setString(1, sykmeldingId)
+            it.execute()
+        }
+        connection.commit()
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/sykmeldingstatus/SykmeldingStatusService.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmeldingstatus/SykmeldingStatusService.kt
@@ -1,7 +1,6 @@
 package no.nav.syfo.sykmeldingstatus
 
 import no.nav.syfo.db.DatabaseInterface
-import no.nav.syfo.log
 
 class SykmeldingStatusService(private val database: DatabaseInterface) {
 
@@ -11,27 +10,11 @@ class SykmeldingStatusService(private val database: DatabaseInterface) {
 
     fun registrerSendt(sykmeldingSendEvent: SykmeldingSendEvent) {
         val sykmeldingStatusEvent = SykmeldingStatusEvent(sykmeldingSendEvent.sykmeldingId, sykmeldingSendEvent.timestamp, StatusEvent.SENDT)
-        registrerStatus(sykmeldingStatusEvent)
-        slettGamleSvarHvisFinnesFraFor(sykmeldingSendEvent.sykmeldingId)
-        database.lagreArbeidsgiver(sykmeldingSendEvent)
-        database.lagreSporsmalOgSvar(sykmeldingSendEvent.sporsmal)
+        database.registrerSendt(sykmeldingSendEvent, sykmeldingStatusEvent)
     }
 
     fun registrerBekreftet(sykmeldingBekreftEvent: SykmeldingBekreftEvent) {
         val sykmeldingStatusEvent = SykmeldingStatusEvent(sykmeldingBekreftEvent.sykmeldingId, sykmeldingBekreftEvent.timestamp, StatusEvent.BEKREFTET)
-        registrerStatus(sykmeldingStatusEvent)
-        slettGamleSvarHvisFinnesFraFor(sykmeldingBekreftEvent.sykmeldingId)
-        sykmeldingBekreftEvent.sporsmal?.forEach {
-            database.lagreSporsmalOgSvar(it)
-        }
-    }
-
-    private fun slettGamleSvarHvisFinnesFraFor(sykmeldingId: String) {
-        val svarFinnesFraFor = database.svarFinnesFraFor(sykmeldingId)
-        if (svarFinnesFraFor) {
-            log.info("Sletter tidligere svar for sykmelding {}", sykmeldingId)
-            database.slettArbeidsgiver(sykmeldingId)
-            database.slettSvar(sykmeldingId)
-        }
+        database.registrerBekreftet(sykmeldingBekreftEvent, sykmeldingStatusEvent)
     }
 }

--- a/src/main/kotlin/no/nav/syfo/sykmeldingstatus/SykmeldingStatusService.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmeldingstatus/SykmeldingStatusService.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.sykmeldingstatus
 
 import no.nav.syfo.db.DatabaseInterface
+import no.nav.syfo.log
 
 class SykmeldingStatusService(private val database: DatabaseInterface) {
 
@@ -11,6 +12,7 @@ class SykmeldingStatusService(private val database: DatabaseInterface) {
     fun registrerSendt(sykmeldingSendEvent: SykmeldingSendEvent) {
         val sykmeldingStatusEvent = SykmeldingStatusEvent(sykmeldingSendEvent.sykmeldingId, sykmeldingSendEvent.timestamp, StatusEvent.SENDT)
         registrerStatus(sykmeldingStatusEvent)
+        slettGamleSvarHvisFinnesFraFor(sykmeldingSendEvent.sykmeldingId)
         database.lagreArbeidsgiver(sykmeldingSendEvent)
         database.lagreSporsmalOgSvar(sykmeldingSendEvent.sporsmal)
     }
@@ -18,8 +20,18 @@ class SykmeldingStatusService(private val database: DatabaseInterface) {
     fun registrerBekreftet(sykmeldingBekreftEvent: SykmeldingBekreftEvent) {
         val sykmeldingStatusEvent = SykmeldingStatusEvent(sykmeldingBekreftEvent.sykmeldingId, sykmeldingBekreftEvent.timestamp, StatusEvent.BEKREFTET)
         registrerStatus(sykmeldingStatusEvent)
+        slettGamleSvarHvisFinnesFraFor(sykmeldingBekreftEvent.sykmeldingId)
         sykmeldingBekreftEvent.sporsmal?.forEach {
             database.lagreSporsmalOgSvar(it)
+        }
+    }
+
+    private fun slettGamleSvarHvisFinnesFraFor(sykmeldingId: String) {
+        val svarFinnesFraFor = database.svarFinnesFraFor(sykmeldingId)
+        if (svarFinnesFraFor) {
+            log.info("Sletter tidligere svar for sykmelding {}", sykmeldingId)
+            database.slettArbeidsgiver(sykmeldingId)
+            database.slettSvar(sykmeldingId)
         }
     }
 }

--- a/src/test/kotlin/no/nav/syfo/sykmeldingstatus/BekreftSykmeldingEndeTilEndeSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/sykmeldingstatus/BekreftSykmeldingEndeTilEndeSpek.kt
@@ -130,9 +130,11 @@ class BekreftSykmeldingEndeTilEndeSpek : Spek({
 
             it("Bekreft uten spørsmål overskriver tidligere svar i databasen") {
                 val sykmeldingId = "uuid"
-                database.registerStatus(SykmeldingStatusEvent(sykmeldingId, LocalDateTime.now().minusMinutes(5), StatusEvent.BEKREFTET))
-                database.lagreSporsmalOgSvar(Sporsmal("Sykmeldt fra ", ShortName.ARBEIDSSITUASJON, Svar(sykmeldingId, 1, Svartype.ARBEIDSSITUASJON, "Selvstendig")))
-                database.lagreSporsmalOgSvar(Sporsmal("Har forsikring?", ShortName.FORSIKRING, Svar(sykmeldingId, 2, Svartype.JA_NEI, "Nei")))
+                handleRequest(HttpMethod.Post, "/sykmeldinger/$sykmeldingId/bekreft") {
+                    setBody(objectMapper.writeValueAsString(SykmeldingBekreftEventDTO(LocalDateTime.now(), lagSporsmalOgSvarDTOListe())))
+                    addHeader("Content-Type", ContentType.Application.Json.toString())
+                }
+
                 val timestamp = LocalDateTime.now()
                 val sykmeldingBekreftEventDTO = SykmeldingBekreftEventDTO(timestamp, null)
                 with(handleRequest(HttpMethod.Post, "/sykmeldinger/$sykmeldingId/bekreft") {

--- a/src/test/kotlin/no/nav/syfo/sykmeldingstatus/BekreftSykmeldingEndeTilEndeSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/sykmeldingstatus/BekreftSykmeldingEndeTilEndeSpek.kt
@@ -100,10 +100,10 @@ class BekreftSykmeldingEndeTilEndeSpek : Spek({
                 }
             }
 
-            it(description = "Bekreft med spørsmål overskriver tidligere svar i databasen", timeout = 170000) {
+            it("Bekreft med spørsmål overskriver tidligere svar i databasen") {
                 val sykmeldingId = "uuid"
                 val spmOgSvarListe = listOf(SporsmalOgSvarDTO("Sykmeldt fra ", ShortNameDTO.ARBEIDSSITUASJON, SvartypeDTO.ARBEIDSSITUASJON, "Selvstendig"),
-                    SporsmalOgSvarDTO("Har forsikring?", ShortNameDTO.FORSIKRING, SvartypeDTO.JA_NEI, "Ja"))
+                    SporsmalOgSvarDTO("Har forsikring?", ShortNameDTO.FORSIKRING, SvartypeDTO.JA_NEI, "Nei"))
 
                 handleRequest(HttpMethod.Post, "/sykmeldinger/$sykmeldingId/bekreft") {
                     setBody(objectMapper.writeValueAsString(SykmeldingBekreftEventDTO(LocalDateTime.now(), spmOgSvarListe)))
@@ -121,10 +121,10 @@ class BekreftSykmeldingEndeTilEndeSpek : Spek({
 
                     status shouldEqual StatusEvent.BEKREFTET
                     sporsmal.size shouldEqual 4
-                    sporsmal[0] shouldEqual Sporsmal("Sykmeldt fra ", ShortName.ARBEIDSSITUASJON, Svar(sykmeldingId, 5, Svartype.ARBEIDSSITUASJON, "Selvstendig"))
-                    sporsmal[1] shouldEqual Sporsmal("Har forsikring?", ShortName.FORSIKRING, Svar(sykmeldingId, 6, Svartype.JA_NEI, "Ja"))
-                    sporsmal[2] shouldEqual Sporsmal("Hatt fravær?", ShortName.FRAVAER, Svar(sykmeldingId, 7, Svartype.JA_NEI, "Ja"))
-                    sporsmal[3] shouldEqual Sporsmal("Når hadde du fravær?", ShortName.PERIODE, Svar(sykmeldingId, 8, Svartype.PERIODER, "{[{\"fom\": \"2019-8-1\", \"tom\": \"2019-8-15\"}, {\"fom\": \"2019-9-1\", \"tom\": \"2019-9-3\"}]}"))
+                    sporsmal[0] shouldEqualSporsmal Sporsmal("Sykmeldt fra ", ShortName.ARBEIDSSITUASJON, Svar(sykmeldingId, 1, Svartype.ARBEIDSSITUASJON, "Selvstendig"))
+                    sporsmal[1] shouldEqualSporsmal Sporsmal("Har forsikring?", ShortName.FORSIKRING, Svar(sykmeldingId, 2, Svartype.JA_NEI, "Ja"))
+                    sporsmal[2] shouldEqualSporsmal Sporsmal("Hatt fravær?", ShortName.FRAVAER, Svar(sykmeldingId, 3, Svartype.JA_NEI, "Ja"))
+                    sporsmal[3] shouldEqualSporsmal Sporsmal("Når hadde du fravær?", ShortName.PERIODE, Svar(sykmeldingId, 4, Svartype.PERIODER, "{[{\"fom\": \"2019-8-1\", \"tom\": \"2019-8-15\"}, {\"fom\": \"2019-9-1\", \"tom\": \"2019-9-3\"}]}"))
                 }
             }
 
@@ -155,4 +155,20 @@ private fun lagSporsmalOgSvarDTOListe(): List<SporsmalOgSvarDTO> {
         SporsmalOgSvarDTO("Har forsikring?", ShortNameDTO.FORSIKRING, SvartypeDTO.JA_NEI, "Ja"),
         SporsmalOgSvarDTO("Hatt fravær?", ShortNameDTO.FRAVAER, SvartypeDTO.JA_NEI, "Ja"),
         SporsmalOgSvarDTO("Når hadde du fravær?", ShortNameDTO.PERIODE, SvartypeDTO.PERIODER, "{[{\"fom\": \"2019-8-1\", \"tom\": \"2019-8-15\"}, {\"fom\": \"2019-9-1\", \"tom\": \"2019-9-3\"}]}"))
+}
+
+infix fun Sporsmal.shouldEqualSporsmal(expected: Sporsmal): Sporsmal = this.apply { sporsmalErLike(expected, this) }
+
+fun sporsmalErLike(forventetSporsmal: Sporsmal, faktiskSporsmal: Sporsmal): Boolean {
+    if (forventetSporsmal.shortName == faktiskSporsmal.shortName && forventetSporsmal.tekst == faktiskSporsmal.tekst && svarErLike(forventetSporsmal.svar, faktiskSporsmal.svar)) {
+        return true
+    }
+    return false
+}
+
+fun svarErLike(forventetSvar: Svar, faktiskSvar: Svar): Boolean {
+    if (forventetSvar.sykmeldingId == faktiskSvar.sykmeldingId && forventetSvar.svar == faktiskSvar.svar && forventetSvar.svartype == faktiskSvar.svartype) {
+        return true
+    }
+    return false
 }

--- a/src/test/kotlin/no/nav/syfo/sykmeldingstatus/SendSykmeldingEndeTilEndeSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/sykmeldingstatus/SendSykmeldingEndeTilEndeSpek.kt
@@ -91,9 +91,11 @@ class SendSykmeldingEndeTilEndeSpek : Spek({
 
             it("Send overskriver eller sletter tidligere svar i databasen") {
                 val sykmeldingId = "uuid"
-                database.registerStatus(SykmeldingStatusEvent(sykmeldingId, LocalDateTime.now().minusMinutes(5), StatusEvent.BEKREFTET))
-                database.lagreSporsmalOgSvar(Sporsmal("Sykmeldt fra ", ShortName.ARBEIDSSITUASJON, Svar(sykmeldingId, 1, Svartype.ARBEIDSSITUASJON, "Selvstendig")))
-                database.lagreSporsmalOgSvar(Sporsmal("Har forsikring?", ShortName.FORSIKRING, Svar(sykmeldingId, 2, Svartype.JA_NEI, "Nei")))
+                database.registrerBekreftet(SykmeldingBekreftEvent(sykmeldingId, LocalDateTime.now().minusMinutes(5), listOf(
+                    Sporsmal("Sykmeldt fra ", ShortName.ARBEIDSSITUASJON, Svar(sykmeldingId, 1, Svartype.ARBEIDSSITUASJON, "Selvstendig")),
+                    Sporsmal("Har forsikring?", ShortName.FORSIKRING, Svar(sykmeldingId, 2, Svartype.JA_NEI, "Nei"))
+                )), SykmeldingStatusEvent(sykmeldingId, LocalDateTime.now().minusMinutes(5), StatusEvent.BEKREFTET))
+
                 with(handleRequest(HttpMethod.Post, "/sykmeldinger/$sykmeldingId/send") {
                     setBody(objectMapper.writeValueAsString(opprettSykmeldingSendEventDTOForArbeidstaker()))
                     addHeader("Content-Type", ContentType.Application.Json.toString())

--- a/src/test/kotlin/no/nav/syfo/sykmeldingstatus/StatusDbUtils.kt
+++ b/src/test/kotlin/no/nav/syfo/sykmeldingstatus/StatusDbUtils.kt
@@ -61,7 +61,8 @@ fun DatabaseInterface.finnStatusForSykmelding(sykmeldingId: String): StatusEvent
             """
                 SELECT event
                 FROM sykmeldingstatus
-                WHERE sykmelding_id=?;
+                WHERE sykmelding_id=?
+                ORDER BY event_timestamp desc;
                 """
         ).use {
             it.setString(1, sykmeldingId)

--- a/src/test/kotlin/no/nav/syfo/testutil/TestDB.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/TestDB.kt
@@ -46,6 +46,9 @@ fun Connection.dropData() {
         connection.prepareStatement("DELETE FROM behandlingsutfall").executeUpdate()
         connection.prepareStatement("DELETE FROM sykmeldingsopplysninger").executeUpdate()
         connection.prepareStatement("DELETE FROM sykmeldingstatus").executeUpdate()
+        connection.prepareStatement("DELETE FROM arbeidsgiver").executeUpdate()
+        connection.prepareStatement("DELETE FROM svar").executeUpdate()
+        connection.prepareStatement("DELETE FROM sporsmal").executeUpdate()
         connection.commit()
     }
 }


### PR DESCRIPTION
Hva jeg har endret: 
1. Når man endrer en allerede bekreftet sykmelding skal alle tidligere svar slettes
2. Det er uheldig om vi får gjort to av tre oppdateringer mot databasen, og så feiler den siste og etterlater alt i en rar tilstand. Jeg har endret alle queryene som brukes for statusendringer slik at spørringer som hører sammen kjøres i samme transaksjon (det er i alle fall det jeg har forsøkt å gjøre, så skrik ut hvis jeg har tenkt feil!). 