### PR TITLE
Manglet info om papirsykmelding i swagger

### DIFF
--- a/api/oas3/syfosmregister-v1.yaml
+++ b/api/oas3/syfosmregister-v1.yaml
@@ -544,6 +544,8 @@ components:
           type: string
         egenmeldt:
           type: boolean
+        papirsykmelding:
+          type: boolean
         harRedusertArbeidsgiverperiode:
           type: boolean
     Prognose:


### PR DESCRIPTION
Apiet returnerer verdien, men vi har visst glemt å legge det til i swaggeren :) 