### PR TITLE
rydder opp i skjerming i nytt api

### DIFF
--- a/src/test/kotlin/no/nav/syfo/sykmelding/model/SykmeldingMapperKtTest.kt
+++ b/src/test/kotlin/no/nav/syfo/sykmelding/model/SykmeldingMapperKtTest.kt
@@ -2,6 +2,9 @@ package no.nav.syfo.sykmelding.model
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import java.time.LocalDate
+import no.nav.syfo.model.RuleInfo
+import no.nav.syfo.model.Status
+import no.nav.syfo.model.ValidationResult
 import no.nav.syfo.objectMapper
 import no.nav.syfo.sykmelding.db.AnnenFraverGrunn
 import no.nav.syfo.sykmelding.db.AnnenFraversArsak
@@ -15,13 +18,20 @@ import org.spekframework.spek2.style.specification.describe
 
 class SykmeldingMapperKtTest : Spek({
 
-    val utdypendeopplysningerJson = "{\"6.2\":{\"6.2.1\":{\"sporsmal\":\"spm\",\"svar\":\"svar\",\"restriksjoner\":[\"SKJERMET_FOR_ARBEIDSGIVER\"]},\"6.2.2\":{\"sporsmal\":\"spm\",\"svar\":\"svar\",\"restriksjoner\":[\"SKJERMET_FOR_ARBEIDSGIVER\"]},\"6.2.3\":{\"sporsmal\":\"spm\",\"svar\":\"svar\",\"restriksjoner\":[\"SKJERMET_FOR_NAV\"]},\"6.2.4\":{\"sporsmal\":\"spm\",\"svar\":\"svar\",\"restriksjoner\":[\"SKJERMET_FOR_ARBEIDSGIVER\"]}}}"
-    val mappedOpplysningerJson = "{\"6.2\":{\"6.2.1\":{\"sporsmal\":\"spm\",\"svar\":\"svar\",\"restriksjoner\":[\"SKJERMET_FOR_ARBEIDSGIVER\"]},\"6.2.2\":{\"sporsmal\":\"spm\",\"svar\":\"svar\",\"restriksjoner\":[\"SKJERMET_FOR_ARBEIDSGIVER\"]},\"6.2.4\":{\"sporsmal\":\"spm\",\"svar\":\"svar\",\"restriksjoner\":[\"SKJERMET_FOR_ARBEIDSGIVER\"]}}}"
+    val utdypendeopplysningerJson = "{\"6.2\":{\"6.2.1\":{\"sporsmal\":\"spm\",\"svar\":\"svar\",\"restriksjoner\":[\"SKJERMET_FOR_ARBEIDSGIVER\"]},\"6.2.2\":{\"sporsmal\":\"spm\",\"svar\":\"svar\",\"restriksjoner\":[\"SKJERMET_FOR_ARBEIDSGIVER\"]},\"6.2.3\":{\"sporsmal\":\"spm\",\"svar\":\"svar\",\"restriksjoner\":[\"SKJERMET_FOR_NAV\"]},\"6.2.4\":{\"sporsmal\":\"spm\",\"svar\":\"svar\",\"restriksjoner\":[\"SKJERMET_FOR_PASIENT\"]}}}"
+    val mappedOpplysningerJson = "{\"6.2\":{\"6.2.1\":{\"sporsmal\":\"spm\",\"svar\":\"svar\",\"restriksjoner\":[\"SKJERMET_FOR_ARBEIDSGIVER\"]},\"6.2.2\":{\"sporsmal\":\"spm\",\"svar\":\"svar\",\"restriksjoner\":[\"SKJERMET_FOR_ARBEIDSGIVER\"]},\"6.2.4\":{\"sporsmal\":\"spm\",\"svar\":\"svar\",\"restriksjoner\":[\"SKJERMET_FOR_PASIENT\"]}}}"
+    val mappedeOpplysningerJsonPasient = "{\"6.2\":{\"6.2.1\":{\"sporsmal\":\"spm\",\"svar\":\"svar\",\"restriksjoner\":[\"SKJERMET_FOR_ARBEIDSGIVER\"]},\"6.2.2\":{\"sporsmal\":\"spm\",\"svar\":\"svar\",\"restriksjoner\":[\"SKJERMET_FOR_ARBEIDSGIVER\"]},\"6.2.3\":{\"sporsmal\":\"spm\",\"svar\":\"svar\",\"restriksjoner\":[\"SKJERMET_FOR_NAV\"]}}}"
+
     describe("Test SykmeldingMapper") {
-        it("Test map utdypendeOpplysninger") {
+        it("Test map utdypendeOpplysninger - ikke pasient") {
             val utdypendeOpplysninger: Map<String, Map<String, SporsmalSvar>> = objectMapper.readValue(utdypendeopplysningerJson)
-            val mappedMap = toUtdypendeOpplysninger(utdypendeOpplysninger)
+            val mappedMap = toUtdypendeOpplysninger(utdypendeOpplysninger, false)
             mappedOpplysningerJson `should equal` objectMapper.writeValueAsString(mappedMap)
+        }
+        it("Test map utdypendeOpplysninger - pasient") {
+            val utdypendeOpplysninger: Map<String, Map<String, SporsmalSvar>> = objectMapper.readValue(utdypendeopplysningerJson)
+            val mappedMap = toUtdypendeOpplysninger(utdypendeOpplysninger, true)
+            mappedeOpplysningerJsonPasient `should equal` objectMapper.writeValueAsString(mappedMap)
         }
         it("test map har ikke redusert arbeidsgiverperiode") {
             val sykmeldingDto = getSykmeldingerDBmodel(perioder = listOf(getPeriode(
@@ -48,7 +58,6 @@ class SykmeldingMapperKtTest : Spek({
             val sykmeldingDto = sykmeldingMedSmittefare.toSykmeldingDTO(sporsmal = emptyList(), ikkeTilgangTilDiagnose = false)
             sykmeldingDto.harRedusertArbeidsgiverperiode shouldEqual true
         }
-
         it("test map har ikke redusert arbeidsgiverperiode ved annen fravarsgrunn ikke smittefare") {
             val sykmeldingDbModel = getSykmeldingerDBmodel(perioder = listOf(getPeriode(
                 fom = LocalDate.of(2020, 3, 10),
@@ -66,6 +75,103 @@ class SykmeldingMapperKtTest : Spek({
 
             val sykmeldingDto = sykmeldingMedSmittefare.toSykmeldingDTO(sporsmal = emptyList(), ikkeTilgangTilDiagnose = false)
             sykmeldingDto.harRedusertArbeidsgiverperiode shouldEqual false
+        }
+        it("tilBehandlingsutfall fjerner regelinfo for manuell hvis pasient") {
+            val validationResult = ValidationResult(Status.INVALID, listOf(
+                RuleInfo("rulename", "sender", "user", Status.MANUAL_PROCESSING),
+                RuleInfo("rulename2", "sender2", "user2", Status.INVALID))
+            )
+
+            val mappetBehandlingsutfall = validationResult.toBehandlingsutfallDTO(true)
+
+            mappetBehandlingsutfall shouldEqual BehandlingsutfallDTO(RegelStatusDTO.INVALID, listOf(RegelinfoDTO("sender2", "user2", "rulename2", RegelStatusDTO.INVALID)))
+        }
+        it("tilBehandlingsutfall fjerner ikke regelinfo for manuell hvis ikke pasient") {
+            val validationResult = ValidationResult(Status.INVALID, listOf(
+                RuleInfo("rulename", "sender", "user", Status.MANUAL_PROCESSING),
+                RuleInfo("rulename2", "sender2", "user2", Status.INVALID))
+            )
+
+            val mappetBehandlingsutfall = validationResult.toBehandlingsutfallDTO(false)
+
+            mappetBehandlingsutfall shouldEqual BehandlingsutfallDTO(RegelStatusDTO.INVALID, listOf(
+                RegelinfoDTO("sender", "user", "rulename", RegelStatusDTO.MANUAL_PROCESSING),
+                RegelinfoDTO("sender2", "user2", "rulename2", RegelStatusDTO.INVALID)))
+        }
+    }
+
+    describe("Test av skjerming") {
+        it("Skal fjerne info hvis ikkeTilgangTilDiagnose er true") {
+            val sykmeldingDbModel = getSykmeldingerDBmodel(perioder = listOf(getPeriode(
+                fom = LocalDate.of(2020, 3, 10),
+                tom = LocalDate.of(2020, 3, 20)
+            )))
+            val sykmeldingMedUtdypendeOpplysninger = sykmeldingDbModel.copy(
+                sykmeldingsDokument = sykmeldingDbModel.sykmeldingsDokument.copy(utdypendeOpplysninger = objectMapper.readValue(utdypendeopplysningerJson))
+            )
+
+            val mappetSykmelding = sykmeldingMedUtdypendeOpplysninger.toSykmeldingDTO(sporsmal = emptyList(), isPasient = false, ikkeTilgangTilDiagnose = true)
+
+            mappetSykmelding.andreTiltak shouldEqual null
+            mappetSykmelding.skjermesForPasient shouldEqual false
+            mappetSykmelding.tiltakNAV shouldEqual null
+            mappetSykmelding.medisinskVurdering shouldEqual null
+            mappetSykmelding.meldingTilNAV shouldEqual null
+            mappetSykmelding.utdypendeOpplysninger shouldEqual emptyMap()
+        }
+        it("Skal fjerne info hvis ikkeTilgangTilDiagnose er true og pasient er skjermet") {
+            val sykmeldingDbModel = getSykmeldingerDBmodel(skjermet = true, perioder = listOf(getPeriode(
+                fom = LocalDate.of(2020, 3, 10),
+                tom = LocalDate.of(2020, 3, 20)
+            )))
+            val sykmeldingMedUtdypendeOpplysninger = sykmeldingDbModel.copy(
+                sykmeldingsDokument = sykmeldingDbModel.sykmeldingsDokument.copy(utdypendeOpplysninger = objectMapper.readValue(utdypendeopplysningerJson))
+            )
+
+            val mappetSykmelding = sykmeldingMedUtdypendeOpplysninger.toSykmeldingDTO(sporsmal = emptyList(), isPasient = false, ikkeTilgangTilDiagnose = true)
+
+            mappetSykmelding.andreTiltak shouldEqual null
+            mappetSykmelding.skjermesForPasient shouldEqual true
+            mappetSykmelding.tiltakNAV shouldEqual null
+            mappetSykmelding.medisinskVurdering shouldEqual null
+            mappetSykmelding.meldingTilNAV shouldEqual null
+            mappetSykmelding.utdypendeOpplysninger shouldEqual emptyMap()
+        }
+        it("Skal fjerne info hvis pasient er skjermet og isPasient er true") {
+            val sykmeldingDbModel = getSykmeldingerDBmodel(skjermet = true, perioder = listOf(getPeriode(
+                fom = LocalDate.of(2020, 3, 10),
+                tom = LocalDate.of(2020, 3, 20)
+            )))
+            val sykmeldingMedUtdypendeOpplysninger = sykmeldingDbModel.copy(
+                sykmeldingsDokument = sykmeldingDbModel.sykmeldingsDokument.copy(utdypendeOpplysninger = objectMapper.readValue(utdypendeopplysningerJson))
+            )
+
+            val mappetSykmelding = sykmeldingMedUtdypendeOpplysninger.toSykmeldingDTO(sporsmal = emptyList(), isPasient = true, ikkeTilgangTilDiagnose = false)
+
+            mappetSykmelding.andreTiltak shouldEqual null
+            mappetSykmelding.skjermesForPasient shouldEqual true
+            mappetSykmelding.tiltakNAV shouldEqual null
+            mappetSykmelding.medisinskVurdering shouldEqual null
+            mappetSykmelding.meldingTilNAV shouldEqual null
+            mappetSykmelding.utdypendeOpplysninger shouldEqual emptyMap()
+        }
+        it("Skal ikke fjerne info hvis pasient er skjermet og isPasient er false") {
+            val sykmeldingDbModel = getSykmeldingerDBmodel(skjermet = true, perioder = listOf(getPeriode(
+                fom = LocalDate.of(2020, 3, 10),
+                tom = LocalDate.of(2020, 3, 20)
+            )))
+            val sykmeldingMedUtdypendeOpplysninger = sykmeldingDbModel.copy(
+                sykmeldingsDokument = sykmeldingDbModel.sykmeldingsDokument.copy(utdypendeOpplysninger = objectMapper.readValue(utdypendeopplysningerJson))
+            )
+
+            val mappetSykmelding = sykmeldingMedUtdypendeOpplysninger.toSykmeldingDTO(sporsmal = emptyList(), isPasient = false, ikkeTilgangTilDiagnose = false)
+
+            mappetSykmelding.andreTiltak shouldEqual "Andre tiltak"
+            mappetSykmelding.skjermesForPasient shouldEqual true
+            mappetSykmelding.tiltakNAV shouldEqual "Tiltak NAV"
+            mappetSykmelding.medisinskVurdering shouldEqual MedisinskVurderingDTO(hovedDiagnose = DiagnoseDTO("L87", "ICPC-2", "Bursitt/tendinitt/synovitt IKA"), biDiagnoser = emptyList(), annenFraversArsak = null, svangerskap = false, yrkesskade = false, yrkesskadeDato = null)
+            mappetSykmelding.meldingTilNAV shouldEqual MeldingTilNavDTO(true, "Masse bistand")
+            mappetSykmelding.utdypendeOpplysninger shouldEqual objectMapper.readValue(mappedOpplysningerJson)
         }
     }
 })

--- a/src/test/kotlin/no/nav/syfo/testutil/TestData.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/TestData.kt
@@ -8,6 +8,7 @@ import no.nav.syfo.VaultSecrets
 import no.nav.syfo.aksessering.api.PeriodetypeDTO
 import no.nav.syfo.model.Status
 import no.nav.syfo.model.ValidationResult
+import no.nav.syfo.sm.Diagnosekoder
 import no.nav.syfo.sykmelding.db.Adresse
 import no.nav.syfo.sykmelding.db.AktivitetIkkeMulig
 import no.nav.syfo.sykmelding.db.Arbeidsgiver
@@ -18,6 +19,7 @@ import no.nav.syfo.sykmelding.db.HarArbeidsgiver
 import no.nav.syfo.sykmelding.db.KontaktMedPasient
 import no.nav.syfo.sykmelding.db.MedisinskArsak
 import no.nav.syfo.sykmelding.db.MedisinskVurdering
+import no.nav.syfo.sykmelding.db.MeldingTilNAV
 import no.nav.syfo.sykmelding.db.Periode
 import no.nav.syfo.sykmelding.db.StatusDbModel
 import no.nav.syfo.sykmelding.db.Sykmelding
@@ -110,21 +112,21 @@ fun getSykmeldingerDBmodel(skjermet: Boolean = false, perioder: List<Periode> = 
                             stillingsprosent = null,
                             yrkesbetegnelse = null),
                     medisinskVurdering = MedisinskVurdering(
-                            hovedDiagnose = Diagnose("system", "kode", "tekst"),
+                            hovedDiagnose = Diagnose(Diagnosekoder.ICPC2_CODE, "L87", "tekst"),
                             biDiagnoser = emptyList(),
                             yrkesskade = false,
                             svangerskap = false,
                             annenFraversArsak = null,
                             yrkesskadeDato = null
                     ),
-                    andreTiltak = null,
+                    andreTiltak = "Andre tiltak",
                     meldingTilArbeidsgiver = null,
                     navnFastlege = null,
                     tiltakArbeidsplassen = null,
                     syketilfelleStartDato = null,
-                    tiltakNAV = null,
+                    tiltakNAV = "Tiltak NAV",
                     prognose = null,
-                    meldingTilNAV = null,
+                    meldingTilNAV = MeldingTilNAV(true, "Masse bistand"),
                     skjermesForPasient = skjermet,
                     behandletTidspunkt = LocalDateTime.now(),
                     behandler = Behandler(


### PR DESCRIPTION
Fjerner hvilke regler som traff fra behandlingsutfall for manuell behandling hvis responsen skal vises for pasient

Hvis responsen skal vises for pasient og pasienten er skjermet, eller hvis diagnose ikke skal vises (f.eks. i det apiet som syfosoknad kaller) fjernes følgende felter: 
- tiltak NAV
- andre tiltak 
- medisinsk vurdering (denne var riktig fra før)
- melding til NAV
- utdypende opplysninger

I tillegg fjernes utdypende opplysninger enkeltvis hvis de er skjermet for pasient (hvis responsen skal vises for pasient) eller hvis de er skjermet for NAV (i alle andre tilfeller)