### PR TITLE
Update to latest endpoint in Syfo-tilgangskontroll

### DIFF
--- a/src/main/kotlin/no/nav/syfo/util/ApiUtils.kt
+++ b/src/main/kotlin/no/nav/syfo/util/ApiUtils.kt
@@ -4,5 +4,7 @@ import io.ktor.application.ApplicationCall
 import io.ktor.application.call
 import io.ktor.util.pipeline.PipelineContext
 
+const val NAV_PERSONIDENT_HEADER = "nav-personident"
+
 fun PipelineContext<Unit, ApplicationCall>.getFnrFromHeader() =
     call.request.headers["fnr"]


### PR DESCRIPTION
Update to latest endpoint that send fnr as a header instead of as a path param.