### PR TITLE
remove production ingress

### DIFF
--- a/naiserator-prod.yaml
+++ b/naiserator-prod.yaml
@@ -96,9 +96,6 @@ spec:
           namespace: team-esyfo
           cluster: prod-fss
         - application: macgyver
-  ingresses:
-    - "https://smregister.intern.nav.no"
-  webproxy: false
   leaderElection: true
   env:
     - name: SYFOTILGANGSKONTROLL_SCOPE


### PR DESCRIPTION
:warning: This is blocked by: :warning: 

* https://github.com/navikt/syfooppfolgingsplanservice being in FSS and can't use service discovery
* ~https://github.com/navikt/helse-smoppslag/blob/4ffd42b9d07eb41ffa2303a29dac5d4aa2fc955e/deploy/prod.yml#L~