### PR TITLE
IS-1856: Add yrkesbetegnelse to ArbeidsgiverDTO

### DIFF
--- a/src/main/kotlin/no/nav/syfo/sykmelding/model/ArbeidsgiverDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/model/ArbeidsgiverDTO.kt
@@ -2,5 +2,6 @@ package no.nav.syfo.sykmelding.model
 
 data class ArbeidsgiverDTO(
     val navn: String?,
+    val yrkesbetegnelse: String?,
     val stillingsprosent: Int?,
 )

--- a/src/main/kotlin/no/nav/syfo/sykmelding/model/SykmeldingMapper.kt
+++ b/src/main/kotlin/no/nav/syfo/sykmelding/model/SykmeldingMapper.kt
@@ -236,7 +236,7 @@ fun KontaktMedPasient.toKontaktMedPasientDTO(): KontaktMedPasientDTO {
 }
 
 fun Arbeidsgiver.toArbeidsgiverDTO(): ArbeidsgiverDTO {
-    return ArbeidsgiverDTO(navn, stillingsprosent)
+    return ArbeidsgiverDTO(navn, yrkesbetegnelse, stillingsprosent)
 }
 
 fun Periode.toSykmeldingsperiodeDTO(sykmeldingId: String): SykmeldingsperiodeDTO {


### PR DESCRIPTION
- Legger til `yrkesbetegnelse` slik at vi kan bruke dette for å vise stilling til den sykemeldte for veilederen. Denne infoen er veldig etterspurt av veilederne og er viktig for dem når de skal vurdere om personen kan jobbe eller ikke.
- Ser i [denne slacksamtalen](https://nav-it.slack.com/archives/CMA3XV997/p1701341138899439) at `yrkesbetegnelse` kan ha dårlig data. Jeg tenker det er en grei løsning i første omgang å bare vise stilling som kommer fra sykemeldingen.  Det er denne informasjonen de baserer seg på i dag, bortsett fra at de da må åpne opp sykemeldingen i gosys.
- Se [trello lapp](https://trello.com/c/3Qd5Xkr9/1856-vise-stilling-man-er-sykmeldt-fra-i-utdraget-fra-sykefrav%C3%A6ret) for bakgrunn for oppgaven